### PR TITLE
fix: revert header to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
                     <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"/>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -68,41 +68,19 @@ body {
 /* Header */
 header {
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
     align-items: center;
     padding: 1rem 2rem;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
+    background: var(--background);
     flex-shrink: 0;
 }
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    width: 100%;
-    max-width: 1200px;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -773,20 +751,13 @@ details[open] .suggested-header::before {
     header {
         padding: 1rem;
         display: flex;
+        justify-content: flex-end;
     }
     
     .header-content {
-        flex-direction: column;
-        gap: 0.75rem;
+        display: flex;
+        justify-content: flex-end;
         align-items: center;
-    }
-    
-    .header-text {
-        text-align: center;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .theme-toggle {


### PR DESCRIPTION
Reverts the header to an older version as requested in issue #2.

## Changes:
- Remove "Course Materials Assistant" header title
- Remove subtitle about asking questions
- Remove horizontal border below header
- Preserve theme toggle functionality
- Update header styling to position toggle on the right

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)